### PR TITLE
docs(v1): HTML page cache is now generally available for VTEX sites

### DIFF
--- a/client/src/content/v1/en/cache/page.mdx
+++ b/client/src/content/v1/en/cache/page.mdx
@@ -4,25 +4,34 @@ description: Full-page HTML caching at the CDN edge for public pages.
 since: 1.0.0
 ---
 
-import Callout from "../../../../components/ui/Callout.astro";
-
-<Callout type="warning">
-  This feature is under active development and is currently available to select sites on an early-access basis.
-</Callout>
-
 ## What is HTML page caching?
 
-For select sites, deco caches the full HTML response at the CDN edge. Instead of every request traveling to the origin server, the edge node returns a previously cached page response.
+deco caches the full HTML response at the CDN edge for eligible pages. Instead of every request traveling to the origin server, the edge node returns a previously cached page response — reducing latency and origin load.
 
-This feature is active on select sites.
+## How to enable
+
+HTML page caching is available to all VTEX sites on deco. To enable it, update your dependencies to the minimum required versions:
+
+| Package | Minimum version |
+|---------|----------------|
+| `deco` | `1.199.0` |
+| `apps` | `0.153.0` |
+
+Update your `deno.json` or run:
+
+```bash
+deno task update
+```
+
+That's it. No environment variables or manual configuration needed.
 
 ## What gets cached
 
-Currently, only public, anonymous page requests are eligible. This scope may expand as the feature evolves.
+Only public, anonymous page requests are eligible:
 
-- Anonymous visitors (no active session)
+- Visitors who are **not** logged in
+- Pages with no active personalized segment (no active campaigns, price tables, or region-specific pricing)
 - Standard page navigation requests
-- Pages without dynamic per-user state
 
 ## What is never cached
 
@@ -37,16 +46,25 @@ The following always bypass the HTML cache and are served fresh from the origin:
 
 ## Cache lifetime
 
-Cache lifetime depends on the `Cache-Control` value in effect — either set by your application code or configured by the deco team for your site.
+The default `Cache-Control` value is:
 
-The default value is `public, max-age=90, s-maxage=90, stale-while-revalidate=30`, meaning:
+```
+public, max-age=90, s-maxage=90, stale-while-revalidate=3600, stale-if-error=86400
+```
 
-- Cached responses are served for **90 seconds**. After that, the next request fetches a fresh response from the origin.
-- A **30-second stale-while-revalidate window** is applied: stale responses are served immediately while a fresh response is fetched in the background.
+This means:
+
+- Cached responses are served for **90 seconds**, after which the next request fetches a fresh response from the origin.
+- A **1-hour stale-while-revalidate window**: stale responses are served immediately while a fresh response is fetched in the background.
+- A **24-hour stale-if-error window**: stale responses are served if the origin returns an error.
+
+To use a custom value, set the `DECO_PAGE_CACHE_CONTROL` environment variable in your site's configuration.
+
+> **Note:** If your application already sets a `Cache-Control` header on a response, that value is used as-is and the platform default is ignored.
 
 ## How to verify
 
-Inspect the `Cache-Control` response header to check whether a page is eligible for HTML caching:
+Inspect the `Cache-Control` response header to confirm a page is eligible for HTML caching:
 
 ```bash
 curl -sI https://www.yoursite.com/ | grep -i cache-control
@@ -55,7 +73,7 @@ curl -sI https://www.yoursite.com/ | grep -i cache-control
 Expected output for an anonymous (cacheable) request:
 
 ```
-cache-control: public, max-age=90, s-maxage=90, stale-while-revalidate=30
+cache-control: public, max-age=90, s-maxage=90, stale-while-revalidate=3600, stale-if-error=86400
 ```
 
 Expected output for a non-cacheable request (e.g., a logged-in user):
@@ -73,13 +91,8 @@ HTML page caching works alongside other caching mechanisms in deco:
 
 A CDN-level HTML cache hit means the page is served entirely from the edge, with no server involvement.
 
-## Configuration
-
-> **Note:** If your application already sets a `Cache-Control` header on a response, that value is used as-is and the platform default is ignored.
-
 ## Limitations
 
-- **Not yet generally available**: HTML page caching is currently enabled on a case-by-case basis. Contact the deco team if you'd like it enabled for your site.
 - **No manual cache purge**: There is currently no way to manually invalidate cached HTML responses. Cached pages expire naturally after the TTL window.
 
 ## Implementation

--- a/client/src/content/v1/pt/cache/page.mdx
+++ b/client/src/content/v1/pt/cache/page.mdx
@@ -4,25 +4,34 @@ description: Cache de HTML completo no edge da CDN para páginas públicas.
 since: 1.0.0
 ---
 
-import Callout from "../../../../components/ui/Callout.astro";
-
-<Callout type="warning">
-  Essa funcionalidade está em desenvolvimento ativo e disponível para sites selecionados em acesso antecipado.
-</Callout>
-
 ## O que é o cache de HTML de página?
 
-Em sites selecionados, a deco cacheia o HTML completo da página no edge da CDN. Em vez de toda requisição percorrer o caminho até o servidor de origem, o nó de edge retorna uma resposta de página previamente cacheada.
+A deco cacheia o HTML completo da página no edge da CDN para páginas elegíveis. Em vez de toda requisição percorrer o caminho até o servidor de origem, o nó de edge retorna uma resposta de página previamente cacheada — reduzindo latência e carga no servidor de origem.
 
-Essa funcionalidade está ativa em sites selecionados.
+## Como habilitar
+
+O cache de HTML está disponível para todos os sites VTEX na deco. Para habilitar, atualize as dependências para as versões mínimas necessárias:
+
+| Pacote | Versão mínima |
+|--------|--------------|
+| `deco` | `1.199.0` |
+| `apps` | `0.153.0` |
+
+Atualize seu `deno.json` ou execute:
+
+```bash
+deno task update
+```
+
+Só isso. Nenhuma variável de ambiente ou configuração manual necessária.
 
 ## O que é cacheado
 
-No momento, apenas requisições de página públicas e anônimas são elegíveis. Esse escopo pode se expandir conforme a funcionalidade evolui.
+Apenas requisições de página públicas e anônimas são elegíveis:
 
-- Visitantes anônimos (sem sessão ativa)
+- Visitantes que **não** estão logados
+- Páginas sem segmento personalizado ativo (sem campanhas, tabelas de preço ou pricing por região ativos)
 - Requisições de navegação de página comuns
-- Páginas sem estado dinâmico por usuário
 
 ## O que nunca é cacheado
 
@@ -37,16 +46,25 @@ Os casos a seguir sempre ignoram o cache de HTML e são servidos diretamente da 
 
 ## Tempo de vida do cache
 
-O tempo de vida do cache depende do valor de `Cache-Control` em vigor — definido pelo código da sua aplicação ou configurado pela equipe deco para o seu site.
+O valor padrão de `Cache-Control` é:
 
-O valor padrão é `public, max-age=90, s-maxage=90, stale-while-revalidate=30`, o que significa:
+```
+public, max-age=90, s-maxage=90, stale-while-revalidate=3600, stale-if-error=86400
+```
+
+Isso significa:
 
 - Respostas cacheadas são servidas por **90 segundos**. Após esse período, a próxima requisição busca uma resposta atualizada da origem.
-- Uma **janela de stale-while-revalidate de 30 segundos** é aplicada: respostas expiradas são servidas imediatamente enquanto uma resposta atualizada é buscada em segundo plano.
+- Uma **janela de stale-while-revalidate de 1 hora**: respostas expiradas são servidas imediatamente enquanto uma resposta atualizada é buscada em segundo plano.
+- Uma **janela de stale-if-error de 24 horas**: respostas expiradas são servidas se o servidor de origem retornar um erro.
+
+Para usar um valor customizado, defina a variável de ambiente `DECO_PAGE_CACHE_CONTROL` na configuração do seu site.
+
+> **Nota:** Se a sua aplicação já define um header `Cache-Control` na resposta, esse valor é usado como está e o padrão da plataforma é ignorado.
 
 ## Como verificar
 
-Inspecione o header `Cache-Control` da resposta para verificar se uma página é elegível para o cache de HTML:
+Inspecione o header `Cache-Control` da resposta para confirmar que uma página é elegível para o cache de HTML:
 
 ```bash
 curl -sI https://www.seusite.com.br/ | grep -i cache-control
@@ -55,7 +73,7 @@ curl -sI https://www.seusite.com.br/ | grep -i cache-control
 Saída esperada para uma requisição anônima (cacheável):
 
 ```
-cache-control: public, max-age=90, s-maxage=90, stale-while-revalidate=30
+cache-control: public, max-age=90, s-maxage=90, stale-while-revalidate=3600, stale-if-error=86400
 ```
 
 Saída esperada para uma requisição não cacheável (ex: usuário logado):
@@ -73,13 +91,8 @@ O cache de HTML de página funciona junto com os outros mecanismos de cache da d
 
 Um cache hit de HTML no nível da CDN significa que a página é servida inteiramente do edge, sem envolver o servidor de origem.
 
-## Configuração
-
-> **Nota:** Se a sua aplicação já define um header `Cache-Control` na resposta, esse valor é usado como está e o padrão da plataforma é ignorado.
-
 ## Limitações
 
-- **Ainda não disponível para todos**: o cache de HTML de página é habilitado caso a caso no momento. Entre em contato com a equipe deco se quiser habilitar no seu site.
 - **Sem purge manual**: atualmente não há como invalidar manualmente respostas HTML cacheadas. As páginas expiram naturalmente após o TTL.
 
 ## Implementação


### PR DESCRIPTION
## Summary

- Removes the early-access warning — feature is now generally available for all VTEX sites
- Adds **How to enable** section: update deps to `deco@1.199.0` + `apps@0.153.0`, no env vars or manual config needed
- Removes the requirement to contact the deco team
- Updates default `Cache-Control` value to match current runtime (`stale-while-revalidate=3600, stale-if-error=86400`)
- Removes "not generally available" from Limitations
- Updated both EN and PT versions

## Related

- deco-cx/deco#1200
- deco-cx/apps#1597

🤖 Generated with [Claude Code](https://claude.com/claude-code)