### PR TITLE
docs(apex-domains): add troubleshooting for AAAA record causing wrong provider routing

### DIFF
--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -77,13 +77,9 @@ Refresh the page and wait until the new entry shows **Active**. Then open the `â
 - Confirm that all three `A` records were added correctly at your DNS provider.
 - DNS propagation can take up to 48 hours in some cases.
 
----
+**Site is still being served by the previous provider (e.g. Deno Deploy) even with correct A records**
 
-## Troubleshooting
-
-**Site is being served by the wrong provider (e.g. Deno Deploy) even with correct A records**
-
-Modern browsers and operating systems prefer IPv6 (AAAA) over IPv4 (A) when both are available. If your domain has an AAAA record pointing to a previous hosting provider, traffic will go there instead of the deco.cx apex-redirect IPs.
+Modern browsers and operating systems prefer IPv6 (AAAA) over IPv4 (A) when both are available. If your domain has a leftover AAAA record from the previous provider, traffic will go there instead of the deco.cx apex-redirect IPs.
 
 Check if an AAAA record exists:
 

--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -76,3 +76,19 @@ Refresh the page and wait until the new entry shows **Active**. Then open the `â
 
 - Confirm that all three `A` records were added correctly at your DNS provider.
 - DNS propagation can take up to 48 hours in some cases.
+
+---
+
+## Troubleshooting
+
+**Site is being served by the wrong provider (e.g. Deno Deploy) even with correct A records**
+
+Modern browsers and operating systems prefer IPv6 (AAAA) over IPv4 (A) when both are available. If your domain has an AAAA record pointing to a previous hosting provider, traffic will go there instead of the deco.cx apex-redirect IPs.
+
+Check if an AAAA record exists:
+
+```bash
+dig AAAA your-domain.com +short
+```
+
+If any address is returned, remove that AAAA record at your DNS provider. The deco.cx apex-redirect service uses IPv4 only â€” no AAAA record should be present on the apex domain.

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -77,13 +77,9 @@ Atualize a página e aguarde até a nova entrada mostrar **Active**. Então abra
 - Confirme que os três registros `A` foram adicionados corretamente no seu provedor de DNS.
 - A propagação do DNS pode levar até 48 horas em alguns casos.
 
----
+**O site continua sendo servido pelo provedor anterior (ex.: Deno Deploy) mesmo com os registros A corretos**
 
-## Troubleshooting
-
-**O site está sendo servido pelo provedor errado (ex.: Deno Deploy) mesmo com os registros A corretos**
-
-Navegadores e sistemas operacionais modernos preferem IPv6 (AAAA) ao IPv4 (A) quando ambos estão disponíveis. Se o seu domínio tiver um registro AAAA apontando para um provedor de hospedagem anterior, o tráfego irá para lá em vez de seguir para os IPs do apex-redirect da deco.cx.
+Navegadores e sistemas operacionais modernos preferem IPv6 (AAAA) ao IPv4 (A) quando ambos estão disponíveis. Se o seu domínio tiver um registro AAAA remanescente do provedor anterior, o tráfego irá para lá em vez de seguir para os IPs do apex-redirect da deco.cx.
 
 Verifique se existe um registro AAAA:
 

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -76,3 +76,19 @@ Atualize a página e aguarde até a nova entrada mostrar **Active**. Então abra
 
 - Confirme que os três registros `A` foram adicionados corretamente no seu provedor de DNS.
 - A propagação do DNS pode levar até 48 horas em alguns casos.
+
+---
+
+## Troubleshooting
+
+**O site está sendo servido pelo provedor errado (ex.: Deno Deploy) mesmo com os registros A corretos**
+
+Navegadores e sistemas operacionais modernos preferem IPv6 (AAAA) ao IPv4 (A) quando ambos estão disponíveis. Se o seu domínio tiver um registro AAAA apontando para um provedor de hospedagem anterior, o tráfego irá para lá em vez de seguir para os IPs do apex-redirect da deco.cx.
+
+Verifique se existe um registro AAAA:
+
+```bash
+dig AAAA seu-dominio.com +short
+```
+
+Se algum endereço for retornado, remova esse registro AAAA no seu provedor de DNS. O serviço de apex-redirect da deco.cx utiliza apenas IPv4 — nenhum registro AAAA deve estar presente no domínio apex.


### PR DESCRIPTION
## Summary

- Add troubleshooting section to apex-domains docs (EN and PT) explaining that a leftover AAAA record pointing to a previous hosting provider (e.g. Deno Deploy) causes browsers to bypass the apex-redirect A records entirely due to IPv6 preference (Happy Eyeballs)
- Instructs users to check for and remove any AAAA record on the apex domain

## Test plan

- [ ] Verify EN and PT pages render correctly in docs
- [ ] Confirm `dig AAAA` command example is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)