### PR TITLE
docs(apex-domains): add step to remove old provider DNS records before migrating

### DIFF
--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -92,15 +92,3 @@ Refresh the page and wait until the new entry shows **Active**. Then open the `â
 
 - Confirm that all three `A` records were added correctly at your DNS provider.
 - DNS propagation can take up to 48 hours in some cases.
-
-**Site is still being served by the previous provider (e.g. Deno Deploy) even with correct A records**
-
-Modern browsers and operating systems prefer IPv6 (AAAA) over IPv4 (A) when both are available. If your domain has a leftover AAAA record from the previous provider, traffic will go there instead of the deco.cx apex-redirect IPs.
-
-Check if an AAAA record exists:
-
-```bash
-dig AAAA your-domain.com +short
-```
-
-If any address is returned, remove that AAAA record at your DNS provider. The deco.cx apex-redirect service uses IPv4 only â€” no AAAA record should be present on the apex domain.

--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -60,6 +60,13 @@ In **Settings → Domains**, click **Add existing domain** and enter the same ap
 
 **Step 2 — Remove old DNS records**
 
+<Callout type="warning">
+  There will be a brief downtime on the apex domain (e.g. `example.com`) between
+  removing the old records and the new certificate being provisioned. Your `www`
+  subdomain (e.g. `www.example.com`) is not affected and will continue working
+  normally throughout the migration.
+</Callout>
+
 At your DNS provider, delete any apex records left from the previous provider before adding the new ones. Records from Deno Deploy, for example, look like this:
 
 | Type | Name | Value |

--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -58,11 +58,27 @@ Not directly — deco.cx sites run on a subdomain (e.g. `www`). However, deco.cx
 
 In **Settings → Domains**, click **Add existing domain** and enter the same apex domain again. Set the redirect subdomain on the next step and confirm. A new entry appears alongside the existing legacy entry.
 
-**Step 2 — Update DNS**
+**Step 2 — Remove old DNS records**
 
-At your DNS provider (where you purchased your domain), replace any existing apex records with the new IPs shown in step 4 above.
+At your DNS provider, delete any apex records left from the previous provider before adding the new ones. Records from Deno Deploy, for example, look like this:
 
-**Step 3 — Delete the legacy entry**
+| Type | Name | Value |
+|------|------|-------|
+| A | @ | `34.120.54.55` |
+| AAAA | @ | `2600:1901:0:6d85::` |
+| CNAME | `_acme-challenge` | `*.acme.deno.dev` |
+
+<Callout type="warning">
+  Leaving old records in place — especially the AAAA record — will cause
+  browsers to keep routing traffic to the previous provider, since IPv6 takes
+  precedence over IPv4.
+</Callout>
+
+**Step 3 — Add the new DNS records**
+
+At your DNS provider, add the three deco.cx apex-redirect IPs shown in step 4 above.
+
+**Step 4 — Delete the legacy entry**
 
 Refresh the page and wait until the new entry shows **Active**. Then open the `…` menu on the **old** entry and choose **Delete**.
 

--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -62,7 +62,7 @@ In **Settings → Domains**, click **Add existing domain** and enter the same ap
 
 <Callout type="warning">
   There will be a brief downtime on the apex domain (e.g. `example.com`) between
-  removing the old records and the new certificate being provisioned. Your `www`
+  removing the old records and the new certificate being provisioned. Your site's
   subdomain (e.g. `www.example.com`) is not affected and will continue working
   normally throughout the migration.
 </Callout>

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -58,11 +58,27 @@ Não diretamente — sites deco.cx rodam em um subdomínio (ex.: `www`). Porém,
 
 Em **Configurações → Domínios**, clique em **Adicionar domínio existente** e informe o mesmo domínio apex. Defina o subdomínio de redirect no próximo passo e confirme. Uma nova entrada aparecerá ao lado da entrada legada existente.
 
-**Passo 2 — Atualize o DNS**
+**Passo 2 — Remova os registros DNS antigos**
 
-No seu provedor de DNS (onde você comprou o seu domínio), substitua os registros apex existentes pelos novos IPs mostrados no passo 4 acima.
+No seu provedor de DNS, exclua os registros apex do provedor anterior antes de adicionar os novos. Registros do Deno Deploy, por exemplo, têm este formato:
 
-**Passo 3 — Exclua a entrada legada**
+| Tipo | Nome | Valor |
+|------|------|-------|
+| A | @ | `34.120.54.55` |
+| AAAA | @ | `2600:1901:0:6d85::` |
+| CNAME | `_acme-challenge` | `*.acme.deno.dev` |
+
+<Callout type="warning">
+  Deixar registros antigos no lugar — especialmente o AAAA — fará com que os
+  navegadores continuem roteando o tráfego para o provedor anterior, pois IPv6
+  tem precedência sobre IPv4.
+</Callout>
+
+**Passo 3 — Adicione os novos registros DNS**
+
+No seu provedor de DNS, adicione os três IPs do apex-redirect da deco.cx mostrados no passo 4 acima.
+
+**Passo 4 — Exclua a entrada legada**
 
 Atualize a página e aguarde até a nova entrada mostrar **Active**. Então abra o menu `…` na entrada **antiga** e escolha **Excluir**.
 

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -63,8 +63,8 @@ Em **Configurações → Domínios**, clique em **Adicionar domínio existente**
 <Callout type="warning">
   Haverá um breve período de indisponibilidade no domínio apex (ex.:
   `example.com`) entre a remoção dos registros antigos e o provisionamento do
-  novo certificado. O subdomínio `www` (ex.: `www.example.com`) não é afetado e
-  continuará funcionando normalmente durante toda a migração.
+  novo certificado. O subdomínio do seu site (ex.: `www.example.com`) não é
+  afetado e continuará funcionando normalmente durante toda a migração.
 </Callout>
 
 No seu provedor de DNS, exclua os registros apex do provedor anterior antes de adicionar os novos. Registros do Deno Deploy, por exemplo, têm este formato:

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -60,6 +60,13 @@ Em **Configurações → Domínios**, clique em **Adicionar domínio existente**
 
 **Passo 2 — Remova os registros DNS antigos**
 
+<Callout type="warning">
+  Haverá um breve período de indisponibilidade no domínio apex (ex.:
+  `example.com`) entre a remoção dos registros antigos e o provisionamento do
+  novo certificado. O subdomínio `www` (ex.: `www.example.com`) não é afetado e
+  continuará funcionando normalmente durante toda a migração.
+</Callout>
+
 No seu provedor de DNS, exclua os registros apex do provedor anterior antes de adicionar os novos. Registros do Deno Deploy, por exemplo, têm este formato:
 
 | Tipo | Nome | Valor |

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -92,15 +92,3 @@ Atualize a página e aguarde até a nova entrada mostrar **Active**. Então abra
 
 - Confirme que os três registros `A` foram adicionados corretamente no seu provedor de DNS.
 - A propagação do DNS pode levar até 48 horas em alguns casos.
-
-**O site continua sendo servido pelo provedor anterior (ex.: Deno Deploy) mesmo com os registros A corretos**
-
-Navegadores e sistemas operacionais modernos preferem IPv6 (AAAA) ao IPv4 (A) quando ambos estão disponíveis. Se o seu domínio tiver um registro AAAA remanescente do provedor anterior, o tráfego irá para lá em vez de seguir para os IPs do apex-redirect da deco.cx.
-
-Verifique se existe um registro AAAA:
-
-```bash
-dig AAAA seu-dominio.com +short
-```
-
-Se algum endereço for retornado, remova esse registro AAAA no seu provedor de DNS. O serviço de apex-redirect da deco.cx utiliza apenas IPv4 — nenhum registro AAAA deve estar presente no domínio apex.


### PR DESCRIPTION
## Summary

- Add explicit step in the migration guide (EN and PT) to remove old DNS records from the previous provider (e.g. Deno Deploy) before adding the new deco.cx apex-redirect IPs
- Shows the typical records to delete: A (GCP IP), AAAA (GCP IPv6), and CNAME `_acme-challenge`
- Callout warns that leaving the AAAA record causes browsers to keep routing to the old provider due to IPv6 preference

## Motivation

Identified in a real incident: a site migrated to deco.cx still had a `2600:1901:0:6d85::` AAAA record (Deno Deploy) on the apex domain. Browsers were connecting via IPv6 to Deno Deploy and getting 404, ignoring the correct A records pointing to the deco.cx apex-redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)