### PR TITLE
docs(apex-domains): soften downtime warning during migration

### DIFF
--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -61,8 +61,7 @@ In **Settings → Domains**, click **Add existing domain** and enter the same ap
 **Step 2 — Remove old DNS records**
 
 <Callout type="warning">
-  There will be a brief downtime on the apex domain (e.g. `example.com`) between
-  removing the old records and the new certificate being provisioned. Your site's
+  There may be downtime on the apex domain during this step. Your site's
   subdomain (e.g. `www.example.com`) is not affected and will continue working
   normally throughout the migration.
 </Callout>

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -61,10 +61,9 @@ Em **Configurações → Domínios**, clique em **Adicionar domínio existente**
 **Passo 2 — Remova os registros DNS antigos**
 
 <Callout type="warning">
-  Haverá um breve período de indisponibilidade no domínio apex (ex.:
-  `example.com`) entre a remoção dos registros antigos e o provisionamento do
-  novo certificado. O subdomínio do seu site (ex.: `www.example.com`) não é
-  afetado e continuará funcionando normalmente durante toda a migração.
+  Pode haver indisponibilidade no domínio apex durante esta etapa. O subdomínio
+  do seu site (ex.: `www.example.com`) não é afetado e continuará funcionando
+  normalmente durante toda a migração.
 </Callout>
 
 No seu provedor de DNS, exclua os registros apex do provedor anterior antes de adicionar os novos. Registros do Deno Deploy, por exemplo, têm este formato:


### PR DESCRIPTION
## Summary

- Change downtime warning from "there will be downtime" to "there may be downtime" — more accurate since downtime only occurs if the certificate isn't provisioned by the time DNS switches over

🤖 Generated with [Claude Code](https://claude.com/claude-code)