### PR TITLE
docs(apex-domains): swap migration steps 2 and 3 to reduce downtime

### DIFF
--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -58,7 +58,11 @@ Not directly — deco.cx sites run on a subdomain (e.g. `www`). However, deco.cx
 
 In **Settings → Domains**, click **Add existing domain** and enter the same apex domain again. Set the redirect subdomain on the next step and confirm. A new entry appears alongside the existing legacy entry.
 
-**Step 2 — Remove old DNS records**
+**Step 2 — Add the new DNS records**
+
+At your DNS provider, add the three deco.cx apex-redirect IPs shown in step 4 above.
+
+**Step 3 — Remove old DNS records**
 
 <Callout type="warning">
   There may be downtime on the apex domain during this step. Your site's
@@ -66,7 +70,7 @@ In **Settings → Domains**, click **Add existing domain** and enter the same ap
   normally throughout the migration.
 </Callout>
 
-At your DNS provider, delete any apex records left from the previous provider before adding the new ones. Records from Deno Deploy, for example, look like this:
+At your DNS provider, delete any apex records left from the previous provider. Records from Deno Deploy, for example, look like this:
 
 | Type | Name | Value |
 |------|------|-------|
@@ -79,10 +83,6 @@ At your DNS provider, delete any apex records left from the previous provider be
   browsers to keep routing traffic to the previous provider, since IPv6 takes
   precedence over IPv4.
 </Callout>
-
-**Step 3 — Add the new DNS records**
-
-At your DNS provider, add the three deco.cx apex-redirect IPs shown in step 4 above.
 
 **Step 4 — Delete the legacy entry**
 
@@ -97,4 +97,12 @@ Refresh the page and wait until the new entry shows **Active**. Then open the `�
 **The new entry won't become Active**
 
 - Confirm that all three `A` records were added correctly at your DNS provider.
+- Make sure the old redirect entries have been removed from your DNS provider. The old entries are:
+
+  | Type | Name | Value |
+  |------|------|-------|
+  | A | @ | `34.120.54.55` |
+  | AAAA | @ | `2600:1901:0:6d85::` |
+  | CNAME | `_acme-challenge` | *(e.g. `_acme.deno.dev.`)* |
+
 - DNS propagation can take up to 48 hours in some cases.

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -58,7 +58,11 @@ Não diretamente — sites deco.cx rodam em um subdomínio (ex.: `www`). Porém,
 
 Em **Configurações → Domínios**, clique em **Adicionar domínio existente** e informe o mesmo domínio apex. Defina o subdomínio de redirect no próximo passo e confirme. Uma nova entrada aparecerá ao lado da entrada legada existente.
 
-**Passo 2 — Remova os registros DNS antigos**
+**Passo 2 — Adicione os novos registros DNS**
+
+No seu provedor de DNS, adicione os três IPs do apex-redirect da deco.cx mostrados no passo 4 acima.
+
+**Passo 3 — Remova os registros DNS antigos**
 
 <Callout type="warning">
   Pode haver indisponibilidade no domínio apex durante esta etapa. O subdomínio
@@ -66,7 +70,7 @@ Em **Configurações → Domínios**, clique em **Adicionar domínio existente**
   normalmente durante toda a migração.
 </Callout>
 
-No seu provedor de DNS, exclua os registros apex do provedor anterior antes de adicionar os novos. Registros do Deno Deploy, por exemplo, têm este formato:
+No seu provedor de DNS, exclua os registros apex do provedor anterior. Registros do Deno Deploy, por exemplo, têm este formato:
 
 | Tipo | Nome | Valor |
 |------|------|-------|
@@ -79,10 +83,6 @@ No seu provedor de DNS, exclua os registros apex do provedor anterior antes de a
   navegadores continuem roteando o tráfego para o provedor anterior, pois IPv6
   tem precedência sobre IPv4.
 </Callout>
-
-**Passo 3 — Adicione os novos registros DNS**
-
-No seu provedor de DNS, adicione os três IPs do apex-redirect da deco.cx mostrados no passo 4 acima.
 
 **Passo 4 — Exclua a entrada legada**
 
@@ -97,4 +97,12 @@ Atualize a página e aguarde até a nova entrada mostrar **Active**. Então abra
 **A nova entrada não fica Active**
 
 - Confirme que os três registros `A` foram adicionados corretamente no seu provedor de DNS.
+- Certifique-se de que as entradas do redirect antigo foram removidas do seu provedor de DNS. As entradas antigas são:
+
+  | Type | Name | Value |
+  |------|------|-------|
+  | A | @ | `34.120.54.55` |
+  | AAAA | @ | `2600:1901:0:6d85::` |
+  | CNAME | `_acme-challenge` | *(ex.: `_acme.deno.dev.`)* |
+
 - A propagação do DNS pode levar até 48 horas em alguns casos.


### PR DESCRIPTION
## Summary

- Swaps Step 2 (Remove old DNS records) and Step 3 (Add new DNS records) in the migration flow for both EN and PT
- New order: add new deco.cx records first, then remove old provider records
- This reduces the downtime window since the apex domain keeps responding while new records propagate

## Test plan

- [ ] Review EN and PT migration steps flow for correctness
- [ ] Confirm callouts and references are still accurate after the swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)