### PR TITLE
docs(apex-domains): clarify apex domain definition in legacy migration callout

### DIFF
--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -49,9 +49,9 @@ Not directly — deco.cx sites run on a subdomain (e.g. `www`). However, deco.cx
 ## Migrating from the Legacy System
 
 <Callout type="warning">
-  If you see a "Legacy redirect detected" banner in the admin, one or more
-  redirect domains on your site are still using the old system and need to be
-  migrated.
+  If you see a "Legacy redirect detected" banner in the admin, one or more apex
+  domains (root domains without a subdomain, e.g. `example.com`) on your site
+  are still using the old redirect system and need to be migrated.
 </Callout>
 
 **Step 1 — Re-add the domain**

--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -57,7 +57,7 @@ Not directly — deco.cx sites run on a subdomain (e.g. `www`). However, deco.cx
   `example.com` (apex) as opposed to `www.example.com` or `loja.example.com`
   (subdomains).
 
-  **Your store will not go down.** The subdomain where your site actually runs
+  **Your site will not go down.** The subdomain where your site actually runs
   (e.g. `www.example.com`) is not affected at any point during the migration.
   Only the apex redirect (e.g. `example.com` → `www.example.com`) goes through
   a brief transition.

--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -50,8 +50,17 @@ Not directly — deco.cx sites run on a subdomain (e.g. `www`). However, deco.cx
 
 <Callout type="warning">
   If you see a "Legacy redirect detected" banner in the admin, one or more apex
-  domains (root domains without a subdomain, e.g. `example.com`) on your site
-  are still using the old redirect system and need to be migrated.
+  domains on your site are still using the old redirect system and need to be
+  migrated.
+
+  **What is an apex domain?** It's the root domain without any subdomain — e.g.
+  `example.com` (apex) as opposed to `www.example.com` or `loja.example.com`
+  (subdomains).
+
+  **Your store will not go down.** The subdomain where your site actually runs
+  (e.g. `www.example.com`) is not affected at any point during the migration.
+  Only the apex redirect (e.g. `example.com` → `www.example.com`) goes through
+  a brief transition.
 </Callout>
 
 **Step 1 — Re-add the domain**

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -50,8 +50,17 @@ Não diretamente — sites deco.cx rodam em um subdomínio (ex.: `www`). Porém,
 
 <Callout type="warning">
   Se você vir um banner "Redirect legado detectado" no admin, um ou mais domínios
-  apex (domínios raiz sem subdomínio, ex.: `example.com`) do seu site ainda usam
-  o sistema de redirect antigo e precisam ser migrados.
+  apex do seu site ainda usam o sistema de redirect antigo e precisam ser
+  migrados.
+
+  **O que é um domínio apex?** É o domínio raiz sem nenhum subdomínio — ex.:
+  `example.com` (apex) em vez de `www.example.com` ou `loja.example.com`
+  (subdomínios).
+
+  **Sua loja não vai sair do ar.** O subdomínio onde o seu site roda de fato
+  (ex.: `www.example.com`) não é afetado em nenhum momento durante a migração.
+  Apenas o redirect apex (ex.: `example.com` → `www.example.com`) passa por uma
+  breve transição.
 </Callout>
 
 **Passo 1 — Adicione novamente o domínio**

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -49,9 +49,9 @@ Não diretamente — sites deco.cx rodam em um subdomínio (ex.: `www`). Porém,
 ## Migrando do Sistema Antigo
 
 <Callout type="warning">
-  Se você vir um banner "Redirect legado detectado" no admin, um ou mais
-  domínios de redirect do seu site ainda usam o sistema antigo e precisam ser
-  migrados.
+  Se você vir um banner "Redirect legado detectado" no admin, um ou mais domínios
+  apex (domínios raiz sem subdomínio, ex.: `example.com`) do seu site ainda usam
+  o sistema de redirect antigo e precisam ser migrados.
 </Callout>
 
 **Passo 1 — Adicione novamente o domínio**

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -57,7 +57,7 @@ Não diretamente — sites deco.cx rodam em um subdomínio (ex.: `www`). Porém,
   `example.com` (apex) em vez de `www.example.com` ou `loja.example.com`
   (subdomínios).
 
-  **Sua loja não vai sair do ar.** O subdomínio onde o seu site roda de fato
+  **Seu site não vai sair do ar.** O subdomínio onde o seu site roda de fato
   (ex.: `www.example.com`) não é afetado em nenhum momento durante a migração.
   Apenas o redirect apex (ex.: `example.com` → `www.example.com`) passa por uma
   breve transição.


### PR DESCRIPTION
## Summary

- Adds an inline definition of apex domain in the warning callout at the top of the migration section
- Readers landing directly on the migration section now understand what type of domain is being migrated without having to scroll up

🤖 Generated with [Claude Code](https://claude.com/claude-code)