### PR TITLE
docs(apex-domains): improve migration clarity for non-technical users

### DIFF
--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -69,17 +69,25 @@ In **Settings → Domains**, click **Add existing domain** and enter the same ap
 
 **Step 2 — Add the new DNS records**
 
-At your DNS provider, add the three deco.cx apex-redirect IPs shown in step 4 above.
+Log in to your DNS provider — this is the service where you registered or manage your domain (e.g. GoDaddy, Cloudflare, Registro.br, Hostgator). Add the following three records:
+
+| Type | Name | Value |
+|------|------|-------|
+| A | @ | `16.148.147.194` |
+| A | @ | `52.32.122.94` |
+| A | @ | `52.35.156.199` |
+
+> **Note:** `@` represents the apex domain itself. Some DNS providers use the full domain name or leave this field blank — check your provider's documentation if unsure.
 
 **Step 3 — Remove old DNS records**
 
 <Callout type="warning">
-  There may be downtime on the apex domain during this step. Your site's
-  subdomain (e.g. `www.example.com`) is not affected and will continue working
-  normally throughout the migration.
+  There may be brief downtime on the apex domain (e.g. `example.com`) during
+  this step. Your site's subdomain (e.g. `www.example.com`) is not affected and
+  will continue working normally.
 </Callout>
 
-At your DNS provider, delete any apex records left from the previous provider. Records from Deno Deploy, for example, look like this:
+Still in your DNS provider, delete the old apex records. If you were previously using deco.cx's legacy system (powered by Deno Deploy), the records to remove look like this:
 
 | Type | Name | Value |
 |------|------|-------|
@@ -88,17 +96,18 @@ At your DNS provider, delete any apex records left from the previous provider. R
 | CNAME | `_acme-challenge` | `*.acme.deno.dev` |
 
 <Callout type="warning">
-  Leaving old records in place — especially the AAAA record — will cause
-  browsers to keep routing traffic to the previous provider, since IPv6 takes
+  Leaving old records in place — especially the `AAAA` record — will cause
+  browsers to keep routing traffic to the old system, since IPv6 takes
   precedence over IPv4.
 </Callout>
 
 **Step 4 — Delete the legacy entry**
 
-Refresh the page and wait until the new entry shows **Active**. Then open the `…` menu on the **old** entry and choose **Delete**.
+Go back to **Settings → Domains** in the deco.cx admin and refresh the page. Wait until the new entry shows **Active** (this can take a few minutes or up to 48 hours depending on DNS propagation). Once it's Active, open the `…` menu on the **old entry** (the one labeled "Legacy") and choose **Delete**.
 
 <Callout type="info">
-  Do not delete the legacy entry before the new one is Active.
+  Do not delete the legacy entry before the new one is Active — otherwise the
+  apex redirect will stop working entirely.
 </Callout>
 
 ## Migration Troubleshooting

--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -97,8 +97,7 @@ Still in your DNS provider, delete the old apex records. If you were previously 
 
 <Callout type="warning">
   Leaving old records in place — especially the `AAAA` record — will cause
-  browsers to keep routing traffic to the old system, since IPv6 takes
-  precedence over IPv4.
+  browsers to keep routing traffic to the old system.
 </Callout>
 
 **Step 4 — Delete the legacy entry**

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -97,8 +97,7 @@ Ainda no seu provedor de DNS, exclua os registros apex antigos. Se você usava o
 
 <Callout type="warning">
   Deixar registros antigos no lugar — especialmente o `AAAA` — fará com que os
-  navegadores continuem roteando o tráfego para o sistema antigo, pois IPv6
-  tem precedência sobre IPv4.
+  navegadores continuem roteando o tráfego para o sistema antigo.
 </Callout>
 
 **Passo 4 — Exclua a entrada legada**

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -69,17 +69,25 @@ Em **Configurações → Domínios**, clique em **Adicionar domínio existente**
 
 **Passo 2 — Adicione os novos registros DNS**
 
-No seu provedor de DNS, adicione os três IPs do apex-redirect da deco.cx mostrados no passo 4 acima.
+Acesse o seu provedor de DNS — é o serviço onde você registrou ou gerencia o seu domínio (ex.: GoDaddy, Cloudflare, Registro.br, Hostgator). Adicione os três registros abaixo:
+
+| Tipo | Nome | Valor |
+|------|------|-------|
+| A | @ | `16.148.147.194` |
+| A | @ | `52.32.122.94` |
+| A | @ | `52.35.156.199` |
+
+> **Obs.:** `@` representa o próprio domínio apex. Alguns provedores usam o nome completo do domínio ou deixam o campo em branco — consulte a documentação do seu provedor se tiver dúvida.
 
 **Passo 3 — Remova os registros DNS antigos**
 
 <Callout type="warning">
-  Pode haver indisponibilidade no domínio apex durante esta etapa. O subdomínio
-  do seu site (ex.: `www.example.com`) não é afetado e continuará funcionando
-  normalmente durante toda a migração.
+  Pode haver breve indisponibilidade no domínio apex (ex.: `example.com`) durante
+  esta etapa. O subdomínio do seu site (ex.: `www.example.com`) não é afetado e
+  continuará funcionando normalmente.
 </Callout>
 
-No seu provedor de DNS, exclua os registros apex do provedor anterior. Registros do Deno Deploy, por exemplo, têm este formato:
+Ainda no seu provedor de DNS, exclua os registros apex antigos. Se você usava o sistema legado da deco.cx (baseado em Deno Deploy), os registros a remover são estes:
 
 | Tipo | Nome | Valor |
 |------|------|-------|
@@ -88,17 +96,18 @@ No seu provedor de DNS, exclua os registros apex do provedor anterior. Registros
 | CNAME | `_acme-challenge` | `*.acme.deno.dev` |
 
 <Callout type="warning">
-  Deixar registros antigos no lugar — especialmente o AAAA — fará com que os
-  navegadores continuem roteando o tráfego para o provedor anterior, pois IPv6
+  Deixar registros antigos no lugar — especialmente o `AAAA` — fará com que os
+  navegadores continuem roteando o tráfego para o sistema antigo, pois IPv6
   tem precedência sobre IPv4.
 </Callout>
 
 **Passo 4 — Exclua a entrada legada**
 
-Atualize a página e aguarde até a nova entrada mostrar **Active**. Então abra o menu `…` na entrada **antiga** e escolha **Excluir**.
+Volte para **Configurações → Domínios** no admin da deco.cx e atualize a página. Aguarde até a nova entrada mostrar **Active** (pode levar alguns minutos ou até 48 horas dependendo da propagação do DNS). Quando estiver Active, abra o menu `…` na **entrada antiga** (a que está marcada como "Legacy") e escolha **Excluir**.
 
 <Callout type="info">
-  Não exclua a entrada legada antes que a nova esteja Active.
+  Não exclua a entrada legada antes que a nova esteja Active — caso contrário o
+  redirect apex vai parar de funcionar completamente.
 </Callout>
 
 ## Troubleshooting da Migração
@@ -108,7 +117,7 @@ Atualize a página e aguarde até a nova entrada mostrar **Active**. Então abra
 - Confirme que os três registros `A` foram adicionados corretamente no seu provedor de DNS.
 - Certifique-se de que as entradas do redirect antigo foram removidas do seu provedor de DNS. As entradas antigas são:
 
-  | Type | Name | Value |
+  | Tipo | Nome | Valor |
   |------|------|-------|
   | A | @ | `34.120.54.55` |
   | AAAA | @ | `2600:1901:0:6d85::` |


### PR DESCRIPTION
## Summary

- Explains what a DNS provider is on first use, with concrete examples (GoDaddy, Cloudflare, Registro.br, Hostgator)
- Repeats the IPs table directly in Step 2 instead of referencing "step 4 above" — no need to scroll
- Clarifies that old DNS records come from the deco.cx legacy system (powered by Deno Deploy)
- Step 4 now identifies the old entry as the one labeled "Legacy" in the UI
- Strengthens the Step 4 warning: explains *why* not to delete early (redirect stops working entirely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)