### PR TITLE
docs(apex-domains): add migration guide shortcut card at top of page

### DIFF
--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -5,6 +5,14 @@ since: 1.1.0
 ---
 
 import Callout from "../../../../../components/ui/Callout.astro";
+import Card from "../../../../../components/ui/Card.astro";
+
+<Card
+  title="Migrating from the legacy system?"
+  description="If you see a 'Legacy redirect detected' banner in the admin, follow the step-by-step migration guide."
+  icon="RefreshCw"
+  action={{ label: "Go to migration guide", href: "#migrating-from-the-legacy-system" }}
+/>
 
 ## What is an Apex Domain?
 

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -5,6 +5,14 @@ since: 1.1.0
 ---
 
 import Callout from "../../../../../components/ui/Callout.astro";
+import Card from "../../../../../components/ui/Card.astro";
+
+<Card
+  title="Migrando do sistema antigo?"
+  description="Se você vir o banner 'Redirect legado detectado' no admin, siga o guia passo a passo de migração."
+  icon="RefreshCw"
+  action={{ label: "Ir para o guia de migração", href: "#migrando-do-sistema-antigo" }}
+/>
 
 ## O que é domínio apex?
 


### PR DESCRIPTION
## Summary

- Adds a `Card` component at the top of the apex domains page (EN and PT) linking directly to the migration guide section
- Uses `icon="RefreshCw"` and contextual description referencing the "Legacy redirect detected" banner
- First use of the `Card` component in MDX content

## Test Plan
- [ ] Verify card renders correctly on the EN page
- [ ] Verify card renders correctly on the PT page
- [ ] Confirm the action link scrolls to the migration section

🤖 Generated with [Claude Code](https://claude.com/claude-code)