### PR TITLE
fix(docs): clarify apex domain migration — no downtime, only brief HTTPS cert gap

### DIFF
--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -89,10 +89,13 @@ Log in to your DNS provider — this is the service where you registered or mana
 
 **Step 3 — Remove old DNS records**
 
-<Callout type="warning">
-  There may be brief downtime on the apex domain (e.g. `example.com`) during
-  this step. Your site's subdomain (e.g. `www.example.com`) is not affected and
-  will continue working normally.
+<Callout type="info">
+  During this step, the apex domain (e.g. `example.com`) will temporarily have no
+  valid HTTPS certificate — **HTTP** requests will continue working normally and
+  the redirect to `www` will not be interrupted. The HTTPS certificate is issued
+  automatically within a few minutes after DNS propagates.
+
+  Your site's subdomain (e.g. `www.example.com`) is not affected at any point.
 </Callout>
 
 Still in your DNS provider, delete the old apex records. If you were previously using deco.cx's legacy system (powered by Deno Deploy), the records to remove look like this:

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -89,10 +89,13 @@ Acesse o seu provedor de DNS — é o serviço onde você registrou ou gerencia 
 
 **Passo 3 — Remova os registros DNS antigos**
 
-<Callout type="warning">
-  Pode haver breve indisponibilidade no domínio apex (ex.: `example.com`) durante
-  esta etapa. O subdomínio do seu site (ex.: `www.example.com`) não é afetado e
-  continuará funcionando normalmente.
+<Callout type="info">
+  Durante esta etapa, o domínio apex (ex.: `example.com`) ficará um breve período
+  sem certificado HTTPS válido — acessos via **HTTP** continuam funcionando
+  normalmente e o redirect para `www` ocorre sem interrupção. O certificado HTTPS
+  é emitido automaticamente em poucos minutos após a propagação do DNS.
+
+  O subdomínio do seu site (ex.: `www.example.com`) não é afetado em nenhum momento.
 </Callout>
 
 Ainda no seu provedor de DNS, exclua os registros apex antigos. Se você usava o sistema legado da deco.cx (baseado em Deno Deploy), os registros a remover são estes:


### PR DESCRIPTION
## Summary

- Corrige a descrição do passo 3 da migração de apex domains
- O texto anterior dizia "pode haver breve indisponibilidade" o que é impreciso
- Na realidade: HTTP redirect funciona imediatamente, apenas o HTTPS do apex fica um breve período sem cert até ser emitido automaticamente
- O site em www nunca é afetado

## Alterações

- PT: `warning` → `info`, texto atualizado para refletir que é só o cert HTTPS que fica pendente, não um downtime real
- EN: mesma correção na versão em inglês

🤖 Generated with [Claude Code](https://claude.ai/claude-code)