### PR TITLE
docs(apex-domains): clarify migration step 4 and remove 48h DNS mention

### DIFF
--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -111,14 +111,7 @@ Still in your DNS provider, delete the old apex records. If you were previously 
   browsers to keep routing traffic to the old system.
 </Callout>
 
-**Step 4 — Clean up (optional)**
-
-Once the new entry shows **Active**, the migration is complete. You can optionally remove the old legacy entry to keep your domain list clean: open the `…` menu on the **old entry** (the one labeled "Legacy") and choose **Delete**.
-
-<Callout type="info">
-  If you choose to delete the legacy entry, make sure the new one is already
-  **Active** first — otherwise the apex redirect will stop working entirely.
-</Callout>
+Once the new entry shows **Active**, the migration is complete. If you want to make sure everything is working, run a request like the one below — only then delete the legacy entry.
 
 **Verifying the migration**
 

--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -111,7 +111,9 @@ Still in your DNS provider, delete the old apex records. If you were previously 
   browsers to keep routing traffic to the old system.
 </Callout>
 
-Once the new entry shows **Active**, the migration is complete. If you want to make sure everything is working, run a request like the one below — only then delete the legacy entry.
+Once the new entry shows **Active**, the migration is complete. If you want to make sure everything is working, run a request like the one below.
+
+You can also delete the legacy entry at this point — it's no longer needed.
 
 **Verifying the migration**
 

--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -50,7 +50,7 @@ Not directly — deco.cx sites run on a subdomain (e.g. `www`). However, deco.cx
 
 > **Note:** `@` represents the apex (root) domain. Some DNS providers use the full domain name or leave this field blank — check your provider's documentation.
 
-**5.** Refresh the **Settings → Domains** page to check the status. Once the certificate is provisioned the entry will show **Active**. This usually takes a few minutes but can take up to 48 hours depending on DNS propagation.
+**5.** Refresh the **Settings → Domains** page to check the status. Once the certificate is provisioned the entry will show **Active**. This usually takes a few minutes.
 
 ---
 
@@ -113,7 +113,7 @@ Still in your DNS provider, delete the old apex records. If you were previously 
 
 **Step 4 — Delete the legacy entry**
 
-Go back to **Settings → Domains** in the deco.cx admin and refresh the page. Wait until the new entry shows **Active** (this can take a few minutes or up to 48 hours depending on DNS propagation). Once it's Active, open the `…` menu on the **old entry** (the one labeled "Legacy") and choose **Delete**.
+Go back to **Settings → Domains** in the deco.cx admin and refresh the page. Wait until the new entry shows **Active** — at that point the migration is complete. Only then open the `…` menu on the **old entry** (the one labeled "Legacy") and choose **Delete**.
 
 <Callout type="info">
   Do not delete the legacy entry before the new one is Active — otherwise the
@@ -152,4 +152,4 @@ If you see `X-Redirect-By: deco`, the migration is complete and the apex redirec
   | AAAA | @ | `2600:1901:0:6d85::` |
   | CNAME | `_acme-challenge` | *(e.g. `_acme.deno.dev.`)* |
 
-- DNS propagation can take up to 48 hours in some cases.
+- DNS propagation can take a few minutes — if the entry is still not Active after 30 minutes, double-check the records above.

--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -111,13 +111,13 @@ Still in your DNS provider, delete the old apex records. If you were previously 
   browsers to keep routing traffic to the old system.
 </Callout>
 
-**Step 4 — Delete the legacy entry**
+**Step 4 — Clean up (optional)**
 
-Go back to **Settings → Domains** in the deco.cx admin and refresh the page. Wait until the new entry shows **Active** — at that point the migration is complete. Only then open the `…` menu on the **old entry** (the one labeled "Legacy") and choose **Delete**.
+Once the new entry shows **Active**, the migration is complete. You can optionally remove the old legacy entry to keep your domain list clean: open the `…` menu on the **old entry** (the one labeled "Legacy") and choose **Delete**.
 
 <Callout type="info">
-  Do not delete the legacy entry before the new one is Active — otherwise the
-  apex redirect will stop working entirely.
+  If you choose to delete the legacy entry, make sure the new one is already
+  **Active** first — otherwise the apex redirect will stop working entirely.
 </Callout>
 
 **Verifying the migration**

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -111,7 +111,9 @@ Ainda no seu provedor de DNS, exclua os registros apex antigos. Se você usava o
   navegadores continuem roteando o tráfego para o sistema antigo.
 </Callout>
 
-Quando a nova entrada mostrar **Active**, a migração está concluída. Se quiser garantir que está tudo correto, faça uma requisição como a abaixo — só então delete a entrada legada com segurança.
+Quando a nova entrada mostrar **Active**, a migração está concluída. Se quiser garantir que está tudo correto, faça uma requisição como a abaixo.
+
+Você também pode deletar a entrada legada neste momento — ela não é mais necessária.
 
 **Verificando a migração**
 

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -111,13 +111,13 @@ Ainda no seu provedor de DNS, exclua os registros apex antigos. Se você usava o
   navegadores continuem roteando o tráfego para o sistema antigo.
 </Callout>
 
-**Passo 4 — Exclua a entrada legada**
+**Passo 4 — Limpeza (opcional)**
 
-Volte para **Configurações → Domínios** no admin da deco.cx e atualize a página. Aguarde até a nova entrada mostrar **Active** — neste momento a migração já está concluída. Somente então abra o menu `…` na **entrada antiga** (a que está marcada como "Legacy") e escolha **Excluir**.
+Quando a nova entrada mostrar **Active**, a migração está concluída. Se quiser, remova a entrada legada para manter a lista de domínios organizada: abra o menu `…` na **entrada antiga** (a marcada como "Legacy") e escolha **Excluir**.
 
 <Callout type="info">
-  Não exclua a entrada legada antes que a nova esteja Active — caso contrário o
-  redirect apex vai parar de funcionar completamente.
+  Se optar por excluir a entrada legada, certifique-se de que a nova já está
+  **Active** — caso contrário o redirect apex vai parar de funcionar completamente.
 </Callout>
 
 **Verificando a migração**

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -50,7 +50,7 @@ Não diretamente — sites deco.cx rodam em um subdomínio (ex.: `www`). Porém,
 
 > **Obs.:** `@` representa o domínio apex (raiz). Alguns provedores de DNS usam o nome completo do domínio ou deixam o campo em branco — consulte a documentação do seu provedor.
 
-**5.** Atualize a página de **Configurações → Domínios** para verificar o status. Quando o certificado for provisionado, a entrada exibirá **Active**. Geralmente isso leva alguns minutos, mas pode levar até 48 horas dependendo da propagação do DNS.
+**5.** Atualize a página de **Configurações → Domínios** para verificar o status. Quando o certificado for provisionado, a entrada exibirá **Active**. Geralmente isso leva alguns minutos.
 
 ---
 
@@ -113,7 +113,7 @@ Ainda no seu provedor de DNS, exclua os registros apex antigos. Se você usava o
 
 **Passo 4 — Exclua a entrada legada**
 
-Volte para **Configurações → Domínios** no admin da deco.cx e atualize a página. Aguarde até a nova entrada mostrar **Active** (pode levar alguns minutos ou até 48 horas dependendo da propagação do DNS). Quando estiver Active, abra o menu `…` na **entrada antiga** (a que está marcada como "Legacy") e escolha **Excluir**.
+Volte para **Configurações → Domínios** no admin da deco.cx e atualize a página. Aguarde até a nova entrada mostrar **Active** — neste momento a migração já está concluída. Somente então abra o menu `…` na **entrada antiga** (a que está marcada como "Legacy") e escolha **Excluir**.
 
 <Callout type="info">
   Não exclua a entrada legada antes que a nova esteja Active — caso contrário o
@@ -152,4 +152,4 @@ Se aparecer `X-Redirect-By: deco`, a migração está completa e o redirect apex
   | AAAA | @ | `2600:1901:0:6d85::` |
   | CNAME | `_acme-challenge` | *(ex.: `_acme.deno.dev.`)* |
 
-- A propagação do DNS pode levar até 48 horas em alguns casos.
+- A propagação do DNS leva alguns minutos — se a entrada ainda não estiver Active após 30 minutos, revise os registros acima.

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -111,14 +111,7 @@ Ainda no seu provedor de DNS, exclua os registros apex antigos. Se você usava o
   navegadores continuem roteando o tráfego para o sistema antigo.
 </Callout>
 
-**Passo 4 — Limpeza (opcional)**
-
-Quando a nova entrada mostrar **Active**, a migração está concluída. Se quiser, remova a entrada legada para manter a lista de domínios organizada: abra o menu `…` na **entrada antiga** (a marcada como "Legacy") e escolha **Excluir**.
-
-<Callout type="info">
-  Se optar por excluir a entrada legada, certifique-se de que a nova já está
-  **Active** — caso contrário o redirect apex vai parar de funcionar completamente.
-</Callout>
+Quando a nova entrada mostrar **Active**, a migração está concluída. Se quiser garantir que está tudo correto, faça uma requisição como a abaixo — só então delete a entrada legada com segurança.
 
 **Verificando a migração**
 


### PR DESCRIPTION
## Summary

- Step 4 of the legacy migration guide now explicitly states that once the new entry shows **Active**, the migration is complete — and only then the user should delete the old entry
- Removed all mentions of "up to 48 hours" for DNS propagation (setup step 5, migration step 4, and troubleshooting section) since DNS propagation is fast nowadays; replaced with "a few minutes" and a 30-minute threshold in the troubleshooting tip

## Test plan

- [ ] Verify EN and PT versions render correctly on the docs site
- [ ] Confirm no other pages reference the 48h language

🤖 Generated with [Claude Code](https://claude.com/claude-code)