### PR TITLE
docs(apex-domains): add troubleshooting for third-party redirects blocking cert issuance

### DIFF
--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -111,7 +111,7 @@ Still in your DNS provider, delete the old apex records. If you were previously 
   browsers to keep routing traffic to the old system.
 </Callout>
 
-Once the new entry shows **Active**, the migration is complete. If you want to make sure everything is working, run a request like the one below.
+After a few minutes the new entry will show **Active** and the migration will be complete. If you want to make sure everything is working, run a request like the one below.
 
 You can also delete the legacy entry at this point — it's no longer needed.
 

--- a/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/en/cms-capabilities/management/apex-domains.mdx
@@ -134,6 +134,21 @@ X-Redirect-By: deco
 
 If you see `X-Redirect-By: deco`, the migration is complete and the apex redirect is running on the new system.
 
+## Troubleshooting
+
+**The certificate is stuck and the entry never becomes Active**
+
+If the DNS records are correctly pointing to deco.cx but the entry remains pending, check whether there is a **redirect rule configured at your DNS provider or CDN** (e.g. a Cloudflare Page Rule or Redirect Rule) that sends all traffic from the apex domain to another address.
+
+When such a rule exists, the Let's Encrypt validation request — which deco.cx sends to `http://yourdomain.com/.well-known/acme-challenge/...` — is intercepted and redirected before it reaches deco.cx servers. Let's Encrypt never receives the expected response, so the certificate cannot be issued.
+
+**The deco.cx redirect and a third-party redirect are mutually exclusive.** If you keep a redirect active at your DNS provider or CDN, deco.cx cannot issue the certificate. You have two options:
+
+- **Use deco.cx's redirect** — remove the redirect rule from your DNS provider/CDN. Once the certificate is issued the entry will become Active automatically.
+- **Keep the third-party redirect** — in this case there is nothing to configure on deco.cx. The `DecoRedirect` entry will remain pending until the external redirect is removed.
+
+---
+
 ## Migration Troubleshooting
 
 **The new entry won't become Active**

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -134,6 +134,21 @@ X-Redirect-By: deco
 
 Se aparecer `X-Redirect-By: deco`, a migração está completa e o redirect apex já está rodando no novo sistema.
 
+## Troubleshooting
+
+**O certificado trava e a entrada nunca fica Active**
+
+Se os registros DNS estão corretamente apontando para a deco.cx mas a entrada continua pendente, verifique se há uma **regra de redirect configurada no seu provedor de DNS ou CDN** (ex.: uma Page Rule ou Redirect Rule na Cloudflare) que envia todo o tráfego do domínio apex para outro endereço.
+
+Quando essa regra existe, a requisição de validação do Let's Encrypt — que a deco.cx envia para `http://seudominio.com/.well-known/acme-challenge/...` — é interceptada e redirecionada antes de chegar aos servidores da deco.cx. O Let's Encrypt nunca recebe a resposta esperada e o certificado não é emitido.
+
+**O redirect da deco.cx e um redirect de terceiro são mutuamente exclusivos.** Se você mantiver um redirect ativo no seu provedor de DNS ou CDN, a deco.cx não consegue emitir o certificado. Você tem duas opções:
+
+- **Usar o redirect da deco.cx** — remova a regra de redirect do seu provedor de DNS/CDN. Assim que o certificado for emitido, a entrada ficará Active automaticamente.
+- **Manter o redirect de terceiro** — nesse caso não há nada para configurar na deco.cx. A entrada ficará pendente até que o redirect externo seja removido.
+
+---
+
 ## Troubleshooting da Migração
 
 **A nova entrada não fica Active**

--- a/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
+++ b/client/src/content/v1/pt/cms-capabilities/management/apex-domains.mdx
@@ -111,7 +111,7 @@ Ainda no seu provedor de DNS, exclua os registros apex antigos. Se você usava o
   navegadores continuem roteando o tráfego para o sistema antigo.
 </Callout>
 
-Quando a nova entrada mostrar **Active**, a migração está concluída. Se quiser garantir que está tudo correto, faça uma requisição como a abaixo.
+Após alguns minutos a nova entrada exibirá **Active** e a migração estará concluída. Se quiser garantir que está tudo correto, faça uma requisição como a abaixo.
 
 Você também pode deletar a entrada legada neste momento — ela não é mais necessária.
 


### PR DESCRIPTION
## Summary

- Adds a **Troubleshooting** section (before the existing Migration Troubleshooting) to both the EN and PT versions of `apex-domains.mdx`
- Explains that a redirect rule configured at the DNS provider or CDN (e.g. Cloudflare Page Rules) intercepts the Let's Encrypt HTTP-01 challenge before it reaches deco.cx, preventing certificate issuance
- Clarifies that the deco.cx redirect and a third-party redirect are mutually exclusive, and presents both options to the user

## Test plan

- [ ] Review EN version renders correctly
- [ ] Review PT version renders correctly
- [ ] Confirm the new section appears between the setup steps and the migration section

🤖 Generated with [Claude Code](https://claude.com/claude-code)