### PR TITLE
docs(framework): renderJson (page-as-JSON for mobile apps) + asJson

### DIFF
--- a/client/src/content/v2/en/framework/render-json.mdx
+++ b/client/src/content/v2/en/framework/render-json.mdx
@@ -103,6 +103,36 @@ A `renderJson` export is invisible to the type system and the admin schema — d
 
 `?asJson` dumps the **entire** resolved page object raw (full props of every eager section, plus admin `resolveChain` metadata). It runs every eager section's loader and serializes everything — multi-MB on a PLP/PDP. It exists for the admin preview and legacy compatibility; prefer `?renderJson` for apps. When both params are present, `?renderJson` wins.
 
+Why `?renderJson` is the better default for apps:
+
+- **Size** — `?asJson` serializes every eager section's full props plus admin `resolveChain` metadata (multi-MB on a PLP/PDP). `?renderJson` projects each section and drops web-only ones, so payloads are a fraction of the size.
+- **No internals** — `?asJson` leaks admin `resolveChain`/metadata and request-derived keys the app can't use. `?renderJson` returns only `{ component, props }`.
+- **Per-section control** — each section decides its own JSON (a `renderJson` projection or `false`), and `sectionsToIgnore` drops app-owned noise. `?asJson` is all-or-nothing.
+- **Lazy + cacheable** — `?renderJson` defers heavy sections (`lazyUrl`) and strips volatile keys for a stable `ETag`. `?asJson` resolves everything eagerly and can't be cached per-page.
+- **Stable contract** — `?renderJson` is a curated shape you version deliberately. `?asJson` mirrors internal resolution and can shift under you.
+
+**Measured example** (a real store, mobile UA):
+
+| Page | `?asJson` | `?renderJson` |
+|---|---|---|
+| Home | ~50 KB · ~0.5 s | ~9 KB · ~0.3 s |
+| Category (PLP) | ~5.5 MB · 3–7 s | ~210 KB · ~0.5 s |
+
+The gap widens on product-heavy pages (PLP/PDP), where `?asJson` ships the full product JSON for every item — on the category above that's a **~26× smaller** payload and roughly **10× faster**. Numbers vary with page, product count, and cache.
+
+## Enabling / disabling
+
+Both `?renderJson` and `?asJson` are on by default. Turn either off site-wide in your `worker-entry.ts`, where you call `createDecoWorkerEntry`:
+
+```ts
+export default createDecoWorkerEntry(serverEntry, {
+  renderJson: false, // disable ?renderJson site-wide
+  asJson: false,     // disable the legacy ?asJson
+});
+```
+
+With a flag off, that query param falls through to the normal HTML page. This is the on/off switch for the **endpoint**; `renderJson.sectionsToIgnore` (on the Website app) controls *which sections* appear when it's on.
+
 ## Choosing
 
 - One datum → [**invoke**](/v2/en/framework/invoke) (`?select=` to trim).

--- a/client/src/content/v2/en/framework/render-json.mdx
+++ b/client/src/content/v2/en/framework/render-json.mdx
@@ -67,7 +67,8 @@ Site-owned sections should prefer `export const renderJson = false` in their own
 ### Response contract
 
 - Envelope: `{ name, path, sections: [{ component, props }] }`.
-- **CORS**: the response reflects the request `Origin` with `Access-Control-Allow-Credentials: true`, so credentialed fetches work.
+- **CORS**: off by default — a native app needs none. Allow browser clients on other origins with `pageJsonCors` (see [Enabling / disabling](#enabling--disabling)).
+- **Secrets stripped**: any `Secret`-typed value (`{ get() }` or an unresolved secret block) is removed from the payload — a mobile app never receives one. A *plaintext* secret a loader put into a string prop can't be auto-detected, so keep secrets as `Secret` and never resolve them into a serialized prop.
 - **Caching**: an `ETag` over the serialized body — the app sends `If-None-Match` and gets `304` when the page is unchanged.
 - **Not found**: a stable `{ status: 404, notFound: true }` (HTTP 404).
 - Request-derived framework keys (`__pageUrl`, `__pagePath`, `device`, `isMobile`) are stripped — they are not content and would bust the ETag per request.
@@ -128,10 +129,16 @@ Both `?renderJson` and `?asJson` are on by default. Turn either off site-wide in
 export default createDecoWorkerEntry(serverEntry, {
   renderJson: false, // disable ?renderJson site-wide
   asJson: false,     // disable the legacy ?asJson
+
+  // Allow browser clients on other origins to read ?renderJson (native apps
+  // need none). Omit for same-origin only; use "*" for any origin (no credentials).
+  pageJsonCors: ["https://app.example.com"],
 });
 ```
 
-With a flag off, that query param falls through to the normal HTML page. This is the on/off switch for the **endpoint**; `renderJson.sectionsToIgnore` (on the Website app) controls *which sections* appear when it's on.
+With a flag off, that query param falls through to the normal HTML page. `renderJson`/`asJson` are the on/off switch for the **endpoint**; `pageJsonCors` controls **which origins** may read it from a browser; `renderJson.sectionsToIgnore` (on the Website app) controls *which sections* appear when it's on.
+
+Migrated sites scaffold with `renderJson` and `asJson` **off** — opt in when you build an app.
 
 ## Choosing
 

--- a/client/src/content/v2/en/framework/render-json.mdx
+++ b/client/src/content/v2/en/framework/render-json.mdx
@@ -1,0 +1,116 @@
+---
+title: "renderJson"
+description: "Serve CMS pages as lean, per-section JSON for native/mobile apps — plus how it compares to invoke and the legacy ?asJson."
+icon: "Smartphone"
+---
+
+import Callout from "../../../../components/ui/Callout.astro";
+
+A v2 storefront can serve its pages as JSON, so a native mobile app (or any non-HTML client) consumes the same CMS-managed pages the web renders. There are three ways in, from most granular to whole-page:
+
+| Way | Returns | Weight | Use when |
+|---|---|---|---|
+| [`/deco/invoke/<key>`](/v2/en/framework/invoke) (+`?select=`) | one loader/action result | lightest | you need one piece of data (a product, cart, search) |
+| `?renderJson` | the resolved page, projected per-section | light (curated) | the app renders a whole CMS page and you control the payload |
+| `?asJson` | the entire resolved page object, raw | heavy | admin preview / legacy compat only |
+
+## `?renderJson` — the page as curated JSON
+
+Append `?renderJson` to any page URL. The framework resolves the CMS page and returns a **lean, per-section-projected** document:
+
+```http
+GET /feminino/bolsas?renderJson
+```
+
+```jsonc
+{
+  "name": "Bolsas",
+  "path": "/feminino/bolsas",
+  "sections": [
+    { "component": "site/sections/product-listing/listing-page.tsx",
+      "props": { /* the section's projected props */ } },
+    { "component": "site/sections/home/home-banner-collection.tsx",
+      "props": { /* … */ } }
+  ]
+}
+```
+
+There is no admin `resolveChain`/metadata envelope (unlike `?asJson`). Each section controls its own JSON through a recognized export — same convention family as `loader`, `action`, and `LoadingFallback`:
+
+```tsx
+// Web-only section (theme, analytics, SEO, scripts): drop it from the JSON.
+// Also a perf short-circuit — a dropped section's loader is NOT run.
+export const renderJson = false;
+
+// Projection: trim the resolved props before serialization. Type it against the
+// section's own props so a rename is compile-checked.
+import { deepOmit } from "@decocms/blocks/sdk";
+export const renderJson = (props: SectionProps<typeof loader>) =>
+  deepOmit(props, "storeConfig", "page.seo", "page.productsMap.*.hasFetchedSimilars");
+
+// No export at all → the section serializes with its full resolved props.
+```
+
+`deepOmit(obj, ...dottedPaths)` removes paths immutably; `*` fans over array elements or record values.
+
+### Dropping sections the site doesn't own
+
+For app-owned sections (from `@decocms/apps-*`) that shouldn't reach the app, set `renderJson.sectionsToIgnore` on the **Website** app (admin/decofile) — matched by resolveType suffix:
+
+```jsonc
+// Website app config
+"renderJson": { "sectionsToIgnore": ["SeoV2.tsx", "DecoAnalytics.tsx"] }
+```
+
+Site-owned sections should prefer `export const renderJson = false` in their own file over a store opinion in `sectionsToIgnore`.
+
+### Response contract
+
+- Envelope: `{ name, path, sections: [{ component, props }] }`.
+- **CORS**: the response reflects the request `Origin` with `Access-Control-Allow-Credentials: true`, so credentialed fetches work.
+- **Caching**: an `ETag` over the serialized body — the app sends `If-None-Match` and gets `304` when the page is unchanged.
+- **Not found**: a stable `{ status: 404, notFound: true }` (HTTP 404).
+- Request-derived framework keys (`__pageUrl`, `__pagePath`, `device`, `isMobile`) are stripped — they are not content and would bust the ETag per request.
+
+### Lazy sections
+
+Sections the CMS marks as deferred (below-the-fold) are not resolved in the page response. They appear as a placeholder, interleaved in page order:
+
+```jsonc
+{ "component": "site/sections/home/shelf.tsx",
+  "lazyUrl": "/feminino/bolsas?renderJson&__section=3" }
+```
+
+The app fetches `lazyUrl` (a plain GET, same origin) when it needs that section — e.g. as it scrolls — and gets the resolved `{ component, props }`. Above-the-fold sections arrive inline; heavy ones load on demand instead of bloating the first response. Treat `lazyUrl` as opaque; only its shape (`{ component, lazyUrl }` vs `{ component, props }`) is the contract.
+
+### Mobile fetch example
+
+```ts
+async function fetchPage(path: string, etag?: string) {
+  const res = await fetch(`https://loja.example.com${path}?renderJson`, {
+    headers: etag ? { "If-None-Match": etag } : {},
+  });
+  if (res.status === 304) return null; // use cached
+  return { page: await res.json(), etag: res.headers.get("ETag") };
+}
+```
+
+<Callout type="warning">
+A `renderJson` export is invisible to the type system and the admin schema — dropping or changing one during a refactor produces **no error anywhere**, the app payload just silently changes. A mobile app is a released binary that can't hot-fix, so guard the projections: keep a snapshot test of each key section's projected shape, and bump a contract version before shipping a breaking change.
+</Callout>
+
+## `?asJson` — legacy / preview only
+
+`?asJson` dumps the **entire** resolved page object raw (full props of every eager section, plus admin `resolveChain` metadata). It runs every eager section's loader and serializes everything — multi-MB on a PLP/PDP. It exists for the admin preview and legacy compatibility; prefer `?renderJson` for apps. When both params are present, `?renderJson` wins.
+
+## Choosing
+
+- One datum → [**invoke**](/v2/en/framework/invoke) (`?select=` to trim).
+- A whole CMS page, payload under your control → **`?renderJson`**.
+- Don't reach for **`?asJson`** in new app code.
+
+## See also
+
+- [Invoke](/v2/en/framework/invoke) — call a single loader/action over HTTP.
+- [Worker entry](/v2/en/framework/worker-entry) — where the `?renderJson` branch runs.
+- [Caching](/v2/en/framework/caching) — page and loader cache profiles.

--- a/client/src/content/v2/pt/framework/render-json.mdx
+++ b/client/src/content/v2/pt/framework/render-json.mdx
@@ -67,7 +67,8 @@ Seções do próprio site devem preferir `export const renderJson = false` no pr
 ### Contrato da resposta
 
 - Envelope: `{ name, path, sections: [{ component, props }] }`.
-- **CORS**: a resposta reflete o `Origin` do request com `Access-Control-Allow-Credentials: true`, para fetches credenciados funcionarem.
+- **CORS**: desligado por padrão — app nativo não precisa. Libere clientes browser de outras origens com `pageJsonCors` (veja [Ativando / desativando](#ativando--desativando)).
+- **Secrets removidos**: qualquer valor do tipo `Secret` (`{ get() }` ou um bloco de secret não-resolvido) é removido do payload — o app mobile nunca recebe um. Um secret em *plaintext* que um loader colocou num prop string não dá pra detectar automaticamente, então mantenha secrets como `Secret` e nunca os resolva num prop serializado.
 - **Cache**: um `ETag` sobre o body serializado — o app manda `If-None-Match` e recebe `304` quando a página não mudou.
 - **Não encontrado**: um envelope estável `{ status: 404, notFound: true }` (HTTP 404).
 - Chaves de framework derivadas do request (`__pageUrl`, `__pagePath`, `device`, `isMobile`) são removidas — não são conteúdo e quebrariam o ETag por request.
@@ -128,10 +129,16 @@ O gap aumenta em páginas cheias de produto (PLP/PDP), onde o `?asJson` manda o 
 export default createDecoWorkerEntry(serverEntry, {
   renderJson: false, // desativa ?renderJson no site todo
   asJson: false,     // desativa o ?asJson legado
+
+  // Libera clientes browser de outras origens a ler o ?renderJson (app nativo
+  // não precisa). Omita para só-mesma-origem; use "*" para qualquer origem (sem credentials).
+  pageJsonCors: ["https://app.example.com"],
 });
 ```
 
-Com a flag desligada, aquele query param cai na página HTML normal. Esse é o liga/desliga do **endpoint**; o `renderJson.sectionsToIgnore` (no app Website) controla *quais seções* aparecem quando ele está ligado.
+Com a flag desligada, aquele query param cai na página HTML normal. `renderJson`/`asJson` são o liga/desliga do **endpoint**; o `pageJsonCors` controla **quais origens** podem ler do browser; o `renderJson.sectionsToIgnore` (no app Website) controla *quais seções* aparecem quando ligado.
+
+Sites migrados nascem com `renderJson` e `asJson` **desligados** — ligue quando for fazer um app.
 
 ## Escolhendo
 

--- a/client/src/content/v2/pt/framework/render-json.mdx
+++ b/client/src/content/v2/pt/framework/render-json.mdx
@@ -1,0 +1,116 @@
+---
+title: "renderJson"
+description: "Sirva páginas do CMS como JSON enxuto por seção para apps nativos/mobile — e como isso se compara ao invoke e ao ?asJson legado."
+icon: "Smartphone"
+---
+
+import Callout from "../../../../components/ui/Callout.astro";
+
+Uma storefront v2 pode servir suas páginas como JSON, para um app mobile nativo (ou qualquer cliente não-HTML) consumir as mesmas páginas do CMS que a web renderiza. Há três caminhos, do mais granular ao de página inteira:
+
+| Caminho | Retorna | Peso | Use quando |
+|---|---|---|---|
+| [`/deco/invoke/<key>`](/v2/pt/framework/invoke) (+`?select=`) | um resultado de loader/action | mais leve | você precisa de um dado pontual (produto, carrinho, busca) |
+| `?renderJson` | a página resolvida, projetada por seção | leve (curado) | o app renderiza uma página inteira do CMS e você controla o payload |
+| `?asJson` | o objeto inteiro da página resolvida, cru | pesado | preview do admin / compat legada apenas |
+
+## `?renderJson` — a página como JSON curado
+
+Adicione `?renderJson` à URL de qualquer página. O framework resolve a página do CMS e devolve um documento **enxuto, projetado por seção**:
+
+```http
+GET /feminino/bolsas?renderJson
+```
+
+```jsonc
+{
+  "name": "Bolsas",
+  "path": "/feminino/bolsas",
+  "sections": [
+    { "component": "site/sections/product-listing/listing-page.tsx",
+      "props": { /* os props projetados da seção */ } },
+    { "component": "site/sections/home/home-banner-collection.tsx",
+      "props": { /* … */ } }
+  ]
+}
+```
+
+Não há envelope de `resolveChain`/metadata do admin (diferente do `?asJson`). Cada seção controla seu próprio JSON por um export reconhecido — mesma família de convenções de `loader`, `action` e `LoadingFallback`:
+
+```tsx
+// Seção só-web (theme, analytics, SEO, scripts): dropa do JSON.
+// Também é um short-circuit de perf — o loader da seção dropada NÃO roda.
+export const renderJson = false;
+
+// Projeção: enxuga os props resolvidos antes da serialização. Tipe contra os
+// props da própria seção para que um rename seja checado em compilação.
+import { deepOmit } from "@decocms/blocks/sdk";
+export const renderJson = (props: SectionProps<typeof loader>) =>
+  deepOmit(props, "storeConfig", "page.seo", "page.productsMap.*.hasFetchedSimilars");
+
+// Sem export nenhum → a seção serializa com os props resolvidos completos.
+```
+
+`deepOmit(obj, ...caminhosPontilhados)` remove caminhos de forma imutável; `*` distribui sobre elementos de array ou valores de record.
+
+### Dropando seções que o site não é dono
+
+Para seções de apps (`@decocms/apps-*`) que não devem chegar ao app, configure `renderJson.sectionsToIgnore` no app **Website** (admin/decofile) — casado por sufixo do resolveType:
+
+```jsonc
+// Config do app Website
+"renderJson": { "sectionsToIgnore": ["SeoV2.tsx", "DecoAnalytics.tsx"] }
+```
+
+Seções do próprio site devem preferir `export const renderJson = false` no próprio arquivo em vez de uma opinião de loja no `sectionsToIgnore`.
+
+### Contrato da resposta
+
+- Envelope: `{ name, path, sections: [{ component, props }] }`.
+- **CORS**: a resposta reflete o `Origin` do request com `Access-Control-Allow-Credentials: true`, para fetches credenciados funcionarem.
+- **Cache**: um `ETag` sobre o body serializado — o app manda `If-None-Match` e recebe `304` quando a página não mudou.
+- **Não encontrado**: um envelope estável `{ status: 404, notFound: true }` (HTTP 404).
+- Chaves de framework derivadas do request (`__pageUrl`, `__pagePath`, `device`, `isMobile`) são removidas — não são conteúdo e quebrariam o ETag por request.
+
+### Seções lazy
+
+Seções que o CMS marca como deferidas (below-the-fold) não são resolvidas na resposta da página. Elas aparecem como um placeholder, interleaved na ordem da página:
+
+```jsonc
+{ "component": "site/sections/home/shelf.tsx",
+  "lazyUrl": "/feminino/bolsas?renderJson&__section=3" }
+```
+
+O app busca o `lazyUrl` (um GET simples, mesma origem) quando precisa daquela seção — por exemplo ao rolar — e recebe o `{ component, props }` resolvido. Seções above-the-fold vêm inline; as pesadas carregam sob demanda em vez de inchar a primeira resposta. Trate `lazyUrl` como opaco; só o formato (`{ component, lazyUrl }` vs `{ component, props }`) é o contrato.
+
+### Exemplo de fetch mobile
+
+```ts
+async function fetchPage(path: string, etag?: string) {
+  const res = await fetch(`https://loja.example.com${path}?renderJson`, {
+    headers: etag ? { "If-None-Match": etag } : {},
+  });
+  if (res.status === 304) return null; // usa o cache
+  return { page: await res.json(), etag: res.headers.get("ETag") };
+}
+```
+
+<Callout type="warning">
+Um export `renderJson` é invisível ao type system e ao schema do admin — dropar ou alterar um num refactor não gera **erro em lugar nenhum**, o payload do app só muda em silêncio. Um app mobile é um binário publicado que não dá hotfix, então proteja as projeções: mantenha um snapshot test do shape projetado de cada seção-chave, e versione o contrato antes de shippar uma mudança quebradora.
+</Callout>
+
+## `?asJson` — legado / preview apenas
+
+`?asJson` despeja o objeto **inteiro** da página resolvida cru (props completos de toda seção eager, mais o metadata `resolveChain` do admin). Ele roda o loader de toda seção eager e serializa tudo — multi-MB num PLP/PDP. Existe para o preview do admin e compat legada; prefira `?renderJson` para apps. Quando os dois params estão presentes, `?renderJson` vence.
+
+## Escolhendo
+
+- Um dado → [**invoke**](/v2/pt/framework/invoke) (`?select=` para enxugar).
+- Uma página inteira do CMS, payload sob seu controle → **`?renderJson`**.
+- Não use **`?asJson`** em código novo de app.
+
+## Veja também
+
+- [Invoke](/v2/pt/framework/invoke) — chamar um único loader/action via HTTP.
+- [Worker entry](/v2/pt/framework/worker-entry) — onde o branch `?renderJson` roda.
+- [Caching](/v2/pt/framework/caching) — perfis de cache de página e loader.

--- a/client/src/content/v2/pt/framework/render-json.mdx
+++ b/client/src/content/v2/pt/framework/render-json.mdx
@@ -103,6 +103,36 @@ Um export `renderJson` é invisível ao type system e ao schema do admin — dro
 
 `?asJson` despeja o objeto **inteiro** da página resolvida cru (props completos de toda seção eager, mais o metadata `resolveChain` do admin). Ele roda o loader de toda seção eager e serializa tudo — multi-MB num PLP/PDP. Existe para o preview do admin e compat legada; prefira `?renderJson` para apps. Quando os dois params estão presentes, `?renderJson` vence.
 
+Por que `?renderJson` é o melhor padrão para apps:
+
+- **Tamanho** — `?asJson` serializa os props completos de toda seção eager mais o metadata `resolveChain` do admin (multi-MB num PLP/PDP). `?renderJson` projeta cada seção e dropa as só-web, então os payloads são uma fração do tamanho.
+- **Sem internals** — `?asJson` vaza `resolveChain`/metadata do admin e chaves derivadas do request que o app não usa. `?renderJson` devolve só `{ component, props }`.
+- **Controle por seção** — cada seção decide seu próprio JSON (uma projeção `renderJson` ou `false`), e o `sectionsToIgnore` dropa ruído de apps. `?asJson` é tudo-ou-nada.
+- **Lazy + cacheável** — `?renderJson` defere seções pesadas (`lazyUrl`) e remove chaves voláteis para um `ETag` estável. `?asJson` resolve tudo eager e não dá para cachear por página.
+- **Contrato estável** — `?renderJson` é um shape curado que você versiona de propósito. `?asJson` espelha a resolução interna e pode mudar sem aviso.
+
+**Exemplo medido** (loja real, UA mobile):
+
+| Página | `?asJson` | `?renderJson` |
+|---|---|---|
+| Home | ~50 KB · ~0,5 s | ~9 KB · ~0,3 s |
+| Categoria (PLP) | ~5,5 MB · 3–7 s | ~210 KB · ~0,5 s |
+
+O gap aumenta em páginas cheias de produto (PLP/PDP), onde o `?asJson` manda o JSON completo de cada item — na categoria acima isso é um payload **~26× menor** e cerca de **10× mais rápido**. Os números variam com a página, a quantidade de produtos e o cache.
+
+## Ativando / desativando
+
+`?renderJson` e `?asJson` vêm ligados por padrão. Desligue qualquer um deles para o site todo no seu `worker-entry.ts`, onde você chama `createDecoWorkerEntry`:
+
+```ts
+export default createDecoWorkerEntry(serverEntry, {
+  renderJson: false, // desativa ?renderJson no site todo
+  asJson: false,     // desativa o ?asJson legado
+});
+```
+
+Com a flag desligada, aquele query param cai na página HTML normal. Esse é o liga/desliga do **endpoint**; o `renderJson.sectionsToIgnore` (no app Website) controla *quais seções* aparecem quando ele está ligado.
+
 ## Escolhendo
 
 - Um dado → [**invoke**](/v2/pt/framework/invoke) (`?select=` para enxugar).


### PR DESCRIPTION
Adds a new framework docs page (en + pt) covering how to serve a storefront as JSON to native/mobile apps: `invoke` for a single loader, `?renderJson` for a curated per-section page envelope (the recommended path), and the legacy `?asJson` for the raw full page. It documents the section `renderJson` export contract (`false` / projection fn / absent), `deepOmit`, `renderJson.sectionsToIgnore`, the response contract (CORS, ETag/304, 404 envelope, stripped framework keys), lazy sections, a mobile fetch example, and a contract-stability caveat. The page lands in the `framework` group and is fully bilingual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)